### PR TITLE
add-todoDelete

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,17 +31,38 @@ def add():
 
 
 # http://127.0.0.1:5000/remove
-@app.route('/remove')
+@app.route('/remove', methods=["POST"])
 def remove():
     # jsonファイルから選択されたデータを削除する
-
+    
     # 1.jsonファイルを開く
-    # 2.削除するデータのid配列を取得
-    # 3.jsonデータの"id"項目が一致するものを削除
-    # 4.jsonファイルに書き込む
+    with open('todo-list.json') as f:
+        json_data = json.load(f)
 
-    # todoリストのデータ自体は返さない
-    pass
+    # 2.削除するデータのid配列を取得(str型→list型)
+    removeIds_unique = request.form.get('checkedIds')
+    removeIds = removeIds_unique.split(',')
+
+    # 3.jsonデータの"id"項目が一致するものを削除
+    for e in removeIds:
+        for i in range(len(json_data)):
+            if json_data[i]['id'] == int(e):
+                del json_data[i]
+                break
+
+    # 4.jsonファイルのidを整列
+    count = 1
+    for e in range(len(json_data)):
+        json_data[e]['id'] = count
+        count = count + 1
+        
+    # 5.jsonファイルに書き込む
+    with open('todo-list.json', 'w') as f:
+        json.dump(json_data, f, ensure_ascii=False, indent=4, sort_keys=True, separators=(',', ': '))
+
+    return jsonify({
+        "status": "append completed"
+    })
 
 
 # http://127.0.0.1:5000/sort

--- a/static/main.js
+++ b/static/main.js
@@ -57,10 +57,23 @@ document.getElementById("remove-submit").addEventListener("click", (e) => {
 
     // データを削除する処理
     // チェックボックスの入った要素のidを取得
-    // 取得したidを渡してpythonのjson削除関数を呼ぶ
+    var n = document.getElementById("tbody").childElementCount;
+    let checkedIds = [];
+    for (i=1;i<=n;i++){
+        todo=document.getElementById(i);
+        if(todo.checked){
+            checkedIds.push(i);
+        }
+    }
 
-    // データを表示
-    init()
+    let array = new FormData();
+    array.append("checkedIds",checkedIds);
+
+    // 取得したidを渡してpythonのjson削除関数を呼ぶ
+    fetch('/remove', { method: 'POST', body: array, }).then(function (response) {
+        // データを表示
+        init()
+    })
 })
 
 // データをソートする(KawaiKohsuke)

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,7 @@
                   <th scope="col">期限</th>
               </tr>
           </thead>
-          <tbody>
+          <tbody id="tbody">
               
           </tbody>
       </table>


### PR DESCRIPTION
削除機能を追加
削除したい項目にチェックを入れて削除ボタンを押すと、jsonファイルからチェックリストに入れた項目と同じidのものを削除し、表示されるtodoも更新される機能を追加。
削除ごとにjosnファイルのidを設定し直しています。